### PR TITLE
Add CPU RAM size warning

### DIFF
--- a/sdxl/finetuning_notebooks_sdxl_lora_dreambooth.ipynb
+++ b/sdxl/finetuning_notebooks_sdxl_lora_dreambooth.ipynb
@@ -20,6 +20,7 @@
         "#@title #(Optional) Check GPU\n",
         "\n",
         "#@markdown To train SDXL lora at least 12GB VRAM is recommended.\n",
+        "#@markdown <br> And you need at least 16GB for CPU RAM, which is unfortunately not available on the free tier in Colab.\n",
         "#@markdown <br>You can check your GPU setup before start.\n",
         "!nvidia-smi"
       ],


### PR DESCRIPTION
## Summarize Changes
1. Added CPU RAM size warning that you need at least 16 GB RAM, which unfortunately is not available on the free tier in Colab. 