### PR TITLE
docs: Update minimum VRAM to 32GB

### DIFF
--- a/flux/finetuning_notebooks_flux_lora_dreambooth.ipynb
+++ b/flux/finetuning_notebooks_flux_lora_dreambooth.ipynb
@@ -19,7 +19,7 @@
       "source": [
         "#@title #(Optional) Check GPU\n",
         "\n",
-        "#@markdown To train flux lora 24GB VRAM is recommended.\n",
+        "#@markdown To train Flux LoRA, at least 32GB VRAM (A100 in Colab) is recommended.\n",
         "#@markdown <br>You can check your GPU setup before start.\n",
         "!nvidia-smi"
       ],


### PR DESCRIPTION
## Summarize Changes
1. Update minimum VRAM  to 32GB when training Flux LoRA
