### PR TITLE
Display `num_repeats` in Colab UI

### DIFF
--- a/wan/finetuning_notebooks_wan_lora.ipynb
+++ b/wan/finetuning_notebooks_wan_lora.ipynb
@@ -7,7 +7,7 @@
         "\n",
         "📌 **This notebook has been updated in [jhj0517/finetuning-notebooks](https://github.com/jhj0517/finetuning-notebooks) repository!**\n",
         "\n",
-        "## Version : 1.0.0\n",
+        "## Version : 1.0.1\n",
         "---"
       ],
       "metadata": {
@@ -205,7 +205,7 @@
         "max_ar = 2.0  # @param {type:\"number\"}\n",
         "num_ar_buckets = 7  # @param {type:\"integer\"}\n",
         "# Reduce as necessary\n",
-        "num_repeats = 5\n",
+        "num_repeats = 5  # @param {type:\"integer\"}\n",
         "\n",
         "# Write dataset.toml\n",
         "dataset_config = {\n",


### PR DESCRIPTION
## Related issues / PRs. 
- https://huggingface.co/jhj0517/Wan2-1-T2V-3B-A-Johns-Dog/discussions/1

## Summarize Changes
1. `num_repeats` is not displayed in the Colab UI, so display it in the Colab UI so the user can control it.
