### PR TITLE
Downgrade `numpy` to 1.26.3

### DIFF
--- a/flux/finetuning_notebooks_flux_lora_dreambooth.ipynb
+++ b/flux/finetuning_notebooks_flux_lora_dreambooth.ipynb
@@ -7,7 +7,7 @@
         "\n",
         "📌 **This notebook has been updated in [jhj0517/finetuning-notebooks](https://github.com/jhj0517/finetuning-notebooks) repository!**\n",
         "\n",
-        "## Version : 1.0.5\n",
+        "## Version : 1.0.6\n",
         "---"
       ],
       "metadata": {
@@ -41,8 +41,16 @@
       "source": [
         "#@title #1. Install Dependencies\n",
         "#@markdown This notebook is powered by https://github.com/ostris/ai-toolkit\n",
-        "!git clone -b fix/gradient-checkpointing https://github.com/jhj0517/ai-toolkit.git\n",
-        "!cd ai-toolkit && git submodule update --init --recursive && pip install -r requirements.txt"
+        "#@markdown <br>You can ignore the \"Restart session\" popup after you run the cell.\n",
+        "!git clone -b fix/numpy-error https://github.com/jhj0517/ai-toolkit.git\n",
+        "%cd ai-toolkit\n",
+        "!git submodule update --init --recursive\n",
+        "!pip install -r requirements.txt\n",
+        "\n",
+        "# To fix numpy incompatibility from https://github.com/ostris/ai-toolkit/issues/267\n",
+        "import os\n",
+        "!pip install --quiet --force-reinstall --no-deps numpy==1.26.3\n",
+        "os.kill(os.getpid(), 9)\n"
       ]
     },
     {


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
- #32 
- https://github.com/ostris/ai-toolkit/issues/267#issuecomment-2745643882
## Summarize Changes
1. Downgrade `numpy` to 1.26.3

After downgrading, I had to restart the whole session in colab.
I'm not sure about why, but it's probably the way it works to downgrade original dependencies in colab.